### PR TITLE
Made launcher region-aware

### DIFF
--- a/dataflowlauncher/parsers/config_parsers/config_parser_main.py
+++ b/dataflowlauncher/parsers/config_parsers/config_parser_main.py
@@ -7,8 +7,8 @@ from dataflowlauncher.parsers.config_parsers.pubsub_config_parser import PubSubC
 from dataflowlauncher.parsers.config_parsers.required_config_parser import RequiredConfigParser
 
 CONFIG_PARSER_ITERABLE = (
-    RequiredConfigParser,
     FlowConfigParser,
+    RequiredConfigParser,
     PomConfigParser,
     PubSubConfigParser
 )

--- a/dataflowlauncher/parsers/config_parsers/required_config_parser.py
+++ b/dataflowlauncher/parsers/config_parsers/required_config_parser.py
@@ -13,7 +13,8 @@ from dataflowlauncher.constants import (
     STAGING_STORAGE_BUCKET,
     STREAM_MODE,
     WORKER_COUNT,
-    WORKER_TYPE
+    WORKER_TYPE,
+    FLOW
 )
 from dataflowlauncher.parsers.config_parsers.base_config_parser import ConfigParser
 from dataflowlauncher.utils.dataflow_utils import get_job_status
@@ -68,7 +69,7 @@ class RequiredConfigParser(ConfigParser):
     def add_update_flag_to_config(config):
         result = dict()
         is_update = 'false'
-        job_running = get_job_status(config[JOB_PROJECT_ID], config[JOB_NAME])
+        job_running = get_job_status(config[JOB_PROJECT_ID], config[JOB_NAME], config[FLOW].get('region'))
         if job_running:
             logging.info("Located currently running job with ID: %s",
                          job_running)

--- a/dataflowlauncher/utils/dataflow_utils.py
+++ b/dataflowlauncher/utils/dataflow_utils.py
@@ -3,17 +3,29 @@ from oauth2client.client import GoogleCredentials
 from googleapiclient import discovery
 
 
-def get_job_status(project_id, flow_name):
+def get_job_status(project_id, flow_name, region):
     """ Returns the status of a dataflow job given a job name."""
     credentials = GoogleCredentials.get_application_default()
     client = discovery.build('dataflow', 'v1b3', credentials=credentials)
 
-    req = client.projects().jobs().list(projectId=project_id)
+    req = make_list_request(client, project_id, region)
     while req is not None:
         res = req.execute()
         for job in res['jobs']:
             if all(['name' in job, job['name'] == flow_name,
                     job['currentState'] == 'JOB_STATE_RUNNING']):
                 return job['id']
-        req = client.projects().jobs().list_next(previous_request=req, previous_response=res)
+        req = make_next_request(client, region, req, res)
     return None
+
+def make_list_request(client, project_id, region):
+    if region == None:
+        return client.projects().jobs().list(projectId=project_id)
+    else:
+        return client.projects().locations().jobs().list(projectId=project_id, location=region)
+
+def make_next_request(client, region, req, res):
+    if (region == None):
+        return client.projects().jobs().list_next(previous_request=req, previous_response=res)
+    else:
+        return client.projects().locations().jobs().list_next(previous_request=req, previous_response=res)

--- a/test/test_config_parsers/test_required_config_parser.py
+++ b/test/test_config_parsers/test_required_config_parser.py
@@ -59,6 +59,7 @@ class TestRequiredConfigParser(TestCase):
         mock_gcs_call.return_value = None
         mock_job_status.return_value = True
         parsed_config = self.parser.get_config_parameters(self.test_file_name)
+        parsed_config['PARAMS'] = {}
         jar_args = self.parser.get_jar_params_from_conf(parsed_config)
         reference_args = dict(
             appName="test",
@@ -115,7 +116,7 @@ class TestRequiredConfigParser(TestCase):
            "required_config_parser.get_job_status", autospec=True)
     def test_add_update_flag_to_config_true(self, mock_job_status):
         mock_job_status.return_value = True
-        sample_config = dict(JOB_PROJECT_ID="test_job", JOB_NAME="test_name")
+        sample_config = dict(JOB_PROJECT_ID="test_job", JOB_NAME="test_name", PARAMS={})
         result = self.parser.add_update_flag_to_config(sample_config)
         self.assertEqual("true", result["update"])
 
@@ -123,7 +124,7 @@ class TestRequiredConfigParser(TestCase):
            "required_config_parser.get_job_status", autospec=True)
     def test_add_update_flag_to_config_false(self, mock_job_status):
         mock_job_status.return_value = False
-        sample_config = dict(JOB_PROJECT_ID="test_job", JOB_NAME="test_name")
+        sample_config = dict(JOB_PROJECT_ID="test_job", JOB_NAME="test_name", PARAMS={})
         result = self.parser.add_update_flag_to_config(sample_config)
         self.assertEqual("false", result["update"])
 


### PR DESCRIPTION
If region is specified as a flow parameter, we need to pass this to the dataflow list request when looking for an active job.