### PR TITLE
Update check for existing topics

### DIFF
--- a/dataflowlauncher/utils/pub_sub_utils.py
+++ b/dataflowlauncher/utils/pub_sub_utils.py
@@ -18,7 +18,10 @@ def get_subscription_name(project_id, sub):
 
 
 def check_if_topic_exists(topic, existing_topics):
-    return {'name': topic} in existing_topics
+    for t in existing_topics:
+        if t.get('name', '') == topic:
+            return True
+    return False
 
 
 def get_list_from_key(key, dictionary):


### PR DESCRIPTION
Currently, the check for topic existence assumes that the structure of the response from Google looks following
```
{'name' : 'some topic name'}
```
This particular check can fail if, for example, we add labels to the topics since the response from Google APIs contains extra key 'labels'. 