### PR TITLE
Add missing gitdb2 library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 GitPython==2.1.7
+gitdb2==3.0.1
 gcloud==0.18.3
 google-api-python-client==1.6.4
 pyhocon==0.3.38

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, find_packages
 
 REQUIREMENTS = [
     "GitPython==2.1.7",
+    "gitdb2==3.0.1",
     "gcloud==0.18.3",
     "google-api-python-client==1.6.4",
     "pyhocon==0.3.38",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ TEST_REQUIREMENTS = [
 ]
 
 setup(name='dataflow_launcher',
-      version='0.1.1',
+      version='0.1.2',
       packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
       description='Launcher for Dataflow jobs',
       url='https://github.com/QubitProducts/dataflow_launcher',


### PR DESCRIPTION
While trying to run the launcher in Python 3.10.6 the following exception reports the missing module

```text
ModuleNotFoundError: No module named 'gitdb.utils.compat'
```

This PR fixes it.