### PR TITLE
CCC-445 Add java_runtime parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Make sure you have `virtualenv` installed.
 
 `--jar_file`: Path to the JAR file. Overrides -j. Default: NONE
 
-`--java_runtime`: Alternative java runtime: Default `/usr/bin/java`
+`--java_runtime`: Alternative java runtime. Default: `/usr/bin/java`
 
 `--ignore_git`: Don't check that the git branch is clean
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Do this by runnning `gcloud init`
 ### How to run it? ###
 `python3 -m dataflowlauncher.launcher`
 
-Make sure you have `flow.conf` in the current directory. In addition, the script assumes that the current directory is the git root or one of its subdirectories.
+Make sure you have `flow.conf` in the current directory. In addition, the script assumes that the current directory resides inside a git repository.
 
 ## PEX Distribution
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Do this by runnning `gcloud init`
 ### How to run it? ###
 `python3 -m dataflowlauncher.launcher`
 
-Make sure you have `flow.conf` in the current directory. In addition, the script assumes that the current directory also contains the git root.
+Make sure you have `flow.conf` in the current directory. In addition, the script assumes that the current directory is the git root or one of its subdirectories.
 
 ## PEX Distribution
 
@@ -45,6 +45,8 @@ Make sure you have `virtualenv` installed.
 `-j` or `--jar_path`: Relative path to the JAR directory. Default: target
 
 `--jar_file`: Path to the JAR file. Overrides -j. Default: NONE
+
+`--java_runtime`: Alternative java runtime: Default `/usr/bin/java`
 
 `--ignore_git`: Don't check that the git branch is clean
 

--- a/dataflowlauncher/launcher.py
+++ b/dataflowlauncher/launcher.py
@@ -59,7 +59,7 @@ def run(args, exec_path):
         artifact, version = parse_pom(pom_path)
         jar_file = get_jar_filename(args.jar_path, artifact, version, config[JAR_NAME_FORMAT])
 
-    return run_with_parameters(parameter_list, args.bypass_prompt,
+    return run_with_parameters(args.java_runtime, parameter_list, args.bypass_prompt,
                                exec_path, jar_file)
 
 
@@ -94,12 +94,12 @@ def print_updated_parameters(updated_parameters, old_parameters):
     print()
 
 
-def run_with_parameters(parameter_list, bypass_prompt, exec_path, jar_filename):
+def run_with_parameters(java_runtime, parameter_list, bypass_prompt, exec_path, jar_filename):
     if not bypass_prompt:
         print()
         input("####### Press enter to continue with the deployment #######\n")
 
-    cmd = ["/usr/bin/java"]
+    cmd = [java_runtime]
     jar_path = os.path.join(exec_path, jar_filename)
     logging.info("Launching job via external process")
     cmd.extend(["-jar", jar_path])

--- a/dataflowlauncher/parsers/cli_parsers/util_cli_parser.py
+++ b/dataflowlauncher/parsers/cli_parsers/util_cli_parser.py
@@ -13,6 +13,9 @@ class UtilCliParser(CliParser):
         util_parsers.add_argument(
             '-b', '--bypass_prompt', action='store_true',
             help='Skip enter key press required before launching. Default: false')
+        util_parsers.add_argument(
+            '--java_runtime', type=str, default='/usr/bin/java',
+            help='Optional java runtime. Default: /usr/bin/java')
 
     def run_preprocessing(self, config_dict, cli_args):
         return None

--- a/dataflowlauncher/utils/dataflow_utils.py
+++ b/dataflowlauncher/utils/dataflow_utils.py
@@ -7,7 +7,7 @@ import logging
 def get_job_status(project_id, flow_name, region):
     """ Returns the status of a dataflow job given a job name."""
     credentials = GoogleCredentials.get_application_default()
-    client = discovery.build('dataflow', 'v1b3', credentials=credentials)
+    client = discovery.build('dataflow', 'v1b3', credentials=credentials, cache_discovery=False)
 
     req = make_list_request(client, project_id, region)
     while req is not None:

--- a/dataflowlauncher/utils/gcs_utils.py
+++ b/dataflowlauncher/utils/gcs_utils.py
@@ -11,7 +11,7 @@ from oauth2client.client import GoogleCredentials
 def create_gcs_if_not_exists(bucket_name, region, project_id):
     """ Creates a GCS bucket if it does not exist."""
     credentials = GoogleCredentials.get_application_default()
-    client = discovery.build('storage', 'v1', credentials=credentials)
+    client = discovery.build('storage', 'v1', credentials=credentials, cache_discovery=False)
     try:
         client.buckets().get(bucket=bucket_name).execute()
     except HttpError as exception:

--- a/dataflowlauncher/utils/git_utils.py
+++ b/dataflowlauncher/utils/git_utils.py
@@ -8,5 +8,5 @@ logging.basicConfig(level=logging.INFO)
 def has_dirty_branch(repo_path):
     """ Ensures that repo is not dirty when deploying to production."""
     logging.debug('Asserting Production Checks')
-    repo = Repo(repo_path)
+    repo = Repo(repo_path, search_parent_directories=True)
     return repo.is_dirty()

--- a/dataflowlauncher/utils/pub_sub_utils.py
+++ b/dataflowlauncher/utils/pub_sub_utils.py
@@ -95,7 +95,7 @@ def setup_pubsub(project_id, topics, subs, create_missing_output_topics,
     from googleapiclient import discovery
 
     credentials = GoogleCredentials.get_application_default()
-    client = discovery.build('pubsub', 'v1', credentials=credentials)
+    client = discovery.build('pubsub', 'v1', credentials=credentials, cache_discovery=False)
     existing_topics = client.projects().topics().list(
         project='projects/{}'.format(project_id)).execute()
     existing_topics = get_list_from_key('topics', existing_topics)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ TEST_REQUIREMENTS = [
 ]
 
 setup(name='dataflow_launcher',
-      version='0.1.2',
+      version='0.1.3',
       packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
       description='Launcher for Dataflow jobs',
       url='https://github.com/QubitProducts/dataflow_launcher',

--- a/test/test_cli_parsers/test_util_cli_parser.py
+++ b/test/test_cli_parsers/test_util_cli_parser.py
@@ -13,6 +13,19 @@ class TestUtilCliParser(TestCase):
         self.assertTrue(args.ignore_git)
         self.assertTrue(args.bypass_prompt)
 
+    def test_java_runtime_default(self):
+        parser = ArgumentParser(prog="PROG")
+        UtilCliParser().add_arguments_group(parser)
+        args = parser.parse_args()
+        self.assertEqual(args.java_runtime, "/usr/bin/java")
+
+    def test_java_runtime(self):
+        parser = ArgumentParser(prog="PROG")
+        java_runtime = "/alternative/java"
+        input_arg_str = "--java_runtime=" + java_runtime
+        UtilCliParser().add_arguments_group(parser)
+        args = parser.parse_args(input_arg_str.split())
+        self.assertEqual(args.java_runtime, java_runtime)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
When attempting to use the dataflow launcher on Windows, I ran into an issue with the hardcoded java location.
Additionally an error is raised when running the dataflow launcher from a folder below the git root.

Proposed fixes:
- Add a `--java_runtime` argument to allow specifying the java runtime to use when launching the dataflow
- Set the `Repo` class' `search_parent_directories` to `True` to allow launching the dataflow from s directory below the git root.

@kuzmiigo commented that the dataflow launcher displays error/warnings during its operation.
[c05d686](https://github.com/QubitProducts/dataflow_launcher/pull/16/commits/c05d686508ccf56ab3b0ef67fef991bb1e2cd64a) prevents the file_cache warnings from popping up.